### PR TITLE
Added attribute pool_arn in datasource ec2_coip

### DIFF
--- a/aws/data_source_aws_ec2_coip_pool.go
+++ b/aws/data_source_aws_ec2_coip_pool.go
@@ -34,6 +34,12 @@ func dataSourceAwsEc2CoipPool() *schema.Resource {
 				Computed: true,
 			},
 
+			"pool_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"tags": tagsSchemaComputed(),
 
 			"filter": ec2CustomFiltersSchema(),
@@ -90,6 +96,7 @@ func dataSourceAwsEc2CoipPoolRead(d *schema.ResourceData, meta interface{}) erro
 	d.SetId(aws.StringValue(coip.PoolId))
 
 	d.Set("local_gateway_route_table_id", coip.LocalGatewayRouteTableId)
+	d.Set("pool_arn", coip.PoolArn)
 
 	if err := d.Set("pool_cidrs", aws.StringValueSlice(coip.PoolCidrs)); err != nil {
 		return fmt.Errorf("error setting pool_cidrs: %s", err)


### PR DESCRIPTION
Added the attribute pool_arn in Data Source: aws_ec2_coip_pool 

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16426

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
datasource/aws_ec2_coip_pool added pool_arn attribute
```
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsEc2CoipPool_Id'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsEc2CoipPool_Id -timeout 120m
=== RUN   TestAccDataSourceAwsEc2CoipPool_Id
=== PAUSE TestAccDataSourceAwsEc2CoipPool_Id
=== CONT  TestAccDataSourceAwsEc2CoipPool_Id
--- PASS: TestAccDataSourceAwsEc2CoipPool_Id (34.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.272s

...
```
