### PR TITLE
attribute reference updated with pool_arn

### DIFF
--- a/website/docs/d/ec2_coip_pool.html.markdown
+++ b/website/docs/d/ec2_coip_pool.html.markdown
@@ -58,3 +58,5 @@ the selected COIP Pool.
 The following attribute is additionally exported:
 
 * `pool_cidrs` - Set of CIDR blocks in pool
+
+* `pool_arn` - ARN of the COIP pool


### PR DESCRIPTION
data source aws_ec2_coip_pool documentation updated with pool_arn attribute

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #16426

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
datasource/aws_ec2_coip_pool added pool_arn attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsEc2CoipPool_Id'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsEc2CoipPool_Id -timeout 120m
=== RUN   TestAccDataSourceAwsEc2CoipPool_Id
=== PAUSE TestAccDataSourceAwsEc2CoipPool_Id
=== CONT  TestAccDataSourceAwsEc2CoipPool_Id
--- PASS: TestAccDataSourceAwsEc2CoipPool_Id (34.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.272s

...
```
