### PR TITLE
optional removed from pool_arn attribute and name changed to arn

### DIFF
--- a/aws/data_source_aws_ec2_coip_pool.go
+++ b/aws/data_source_aws_ec2_coip_pool.go
@@ -29,14 +29,16 @@ func dataSourceAwsEc2CoipPool() *schema.Resource {
 			},
 
 			"pool_id": {
+
+
+				
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"pool_arn": {
+			"arn": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
@@ -96,7 +98,7 @@ func dataSourceAwsEc2CoipPoolRead(d *schema.ResourceData, meta interface{}) erro
 	d.SetId(aws.StringValue(coip.PoolId))
 
 	d.Set("local_gateway_route_table_id", coip.LocalGatewayRouteTableId)
-	d.Set("pool_arn", coip.PoolArn)
+	d.Set("arn", coip.PoolArn)
 
 	if err := d.Set("pool_cidrs", aws.StringValueSlice(coip.PoolCidrs)); err != nil {
 		return fmt.Errorf("error setting pool_cidrs: %s", err)


### PR DESCRIPTION
data_source_ec2_coip_pool.go
pool_arn -> arn
pool_arn : removed from optional

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
]$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsEc2CoipPool_Id'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsEc2CoipPool_Id -timeout 120m
=== RUN   TestAccDataSourceAwsEc2CoipPool_Id
=== PAUSE TestAccDataSourceAwsEc2CoipPool_Id
=== CONT  TestAccDataSourceAwsEc2CoipPool_Id
--- PASS: TestAccDataSourceAwsEc2CoipPool_Id (34.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.143s

...
```
